### PR TITLE
fix(sort): Works even for empty configurations

### DIFF
--- a/lib/jsonapi/scopes/sorts.rb
+++ b/lib/jsonapi/scopes/sorts.rb
@@ -29,16 +29,16 @@ module Jsonapi
           raise InvalidAttributeError, "#{field} is not valid as sort attribute." unless allowed_fields.include?(field)
         end
 
-        res = self
+        res = all
 
         order_to_follow = ordered_fields.presence || default_order
         order_to_follow.each do |single_order_q, direction|
           if single_order_q.to_s.include? 'scope:'
             scope_name = single_order_q.to_s.split(':').last
 
-            res = send(scope_name.to_sym, direction)
+            res = res.send(scope_name.to_sym, direction)
           else
-            res = order("#{single_order_q}": direction)
+            res = res.order("#{single_order_q}": direction)
           end
         end
 


### PR DESCRIPTION
When no `default_sort` is defined for the target class, doesn't remove previously defined query conditions.

Before this change:

```ruby
MyModel.where(id: 3).apply_sort({})
```

`apply_sort` would remove `where(id: 3)` when `MyModel` doesn't include the definition of `default_sort`.

This was happening because the empty behavior were returning the model class instead of an ActiveRecord relation based on the same class, therefore beaking the scopes chaining.

With this change, the returned object is an ActiveRecord relation even when no `default_sort` is defined.