### PR TITLE
feature(allowed_includes): adds convenience `allowed_includes_list` class method

### DIFF
--- a/lib/jsonapi/scopes/includes.rb
+++ b/lib/jsonapi/scopes/includes.rb
@@ -13,6 +13,8 @@ module Jsonapi
         @allowed_includes = fields
       end
 
+      def allowed_includes_list = @allowed_includes
+
       def apply_include(params = {}, options = { allowed: [] })
         records = all
         fields = params.dig(:include).to_s

--- a/test/dummy/spec/models/user_spec.rb
+++ b/test/dummy/spec/models/user_spec.rb
@@ -11,6 +11,26 @@ RSpec.describe User, type: :model do
     it 'responds to allowed_includes' do
       expect(User).to respond_to(:allowed_includes)
     end
+
+    it 'responds to allowed_includes_list' do
+      expect(User).to respond_to(:allowed_includes_list)
+    end
+  end
+
+  describe '#allowed_includes_list' do
+    after do
+      User.allowed_includes 'contact', 'posts.contact.users', 'posts', 'posts.user'
+    end
+
+    it 'returns the configured allowed includes' do
+      expect(User.allowed_includes_list).to eq(['contact', 'posts.contact.users', 'posts', 'posts.user'])
+    end
+
+    it 'reflects updates made through allowed_includes' do
+      User.allowed_includes 'contact', 'posts'
+
+      expect(User.allowed_includes_list).to eq(['contact', 'posts'])
+    end
   end
 
   describe '#apply_include' do


### PR DESCRIPTION
Expose allowed_includes_list on include-enabled models and cover it with specs to verify it returns the current configured include list.